### PR TITLE
Add version qualifier check.

### DIFF
--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -22,18 +22,15 @@
 
 (def ^:private QUALIFIERS
   "Order map for well-known Clojure version qualifiers."
-  { "alpha"  0
-    "beta"   1
-    "rc"     2
-    ""       3})
+  { "alpha" 0 "beta" 1 "rc" 2 "" 3})
 
 (defn- assert-clojure-version!
   "Warn user if Clojure 1.7 or greater is not found"
   [pod]
   (let [{:keys [major minor incremental qualifier]} (pod/with-eval-in @pod *clojure-version*)
         [qualifier-part1 qualifier-part2] (if-let [[_ w d] (re-find #"(\w+)(\d+)" (or qualifier ""))]
-                                          [(get QUALIFIERS w) (Integer/parseInt d)]
-                                          [3 0])]
+                                            [(get QUALIFIERS w) (Integer/parseInt d)]
+                                            [3 0])]
     (when-not (>= (compare [major minor incremental qualifier-part1 qualifier-part2] [1 7 0 3 0]) 0)
       (warn "ClojureScript requires Clojure 1.7 or greater.\nSee https://github.com/boot-clj/boot/wiki/Setting-Clojure-version.\n"))))
 


### PR DESCRIPTION
Current Clojure version check doesn't take qualifiers into account so it doesn't warn the user about using `1.7.0-alpha2` which is not compatible with latest ClojureScript.
This PR adds a qualifier check (for well known Clojure qualifiers).

Tested with Clojure `1.6.0`:
![image](https://cloud.githubusercontent.com/assets/2522010/8773474/73479334-2ecc-11e5-8e87-96fac07335b7.png)


With `1.7.0-alpha2`:
![image](https://cloud.githubusercontent.com/assets/2522010/8773441/3bd2973c-2ecc-11e5-9076-9dcfb5f2c1f2.png)


With `1.7.0`:
![image](https://cloud.githubusercontent.com/assets/2522010/8773393/f3c2386c-2ecb-11e5-8f34-deee2d30305d.png)


With `1.8.0-alpha1`:
![image](https://cloud.githubusercontent.com/assets/2522010/8773510/ad572c24-2ecc-11e5-8c01-67b9a7059b4c.png)
