### PR TITLE
Add missing deps, travis config, cleanup, docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: clojure
+install:
+  - curl -s https://api.github.com/repos/boot-clj/boot/releases |grep 'download_url.*boot\.sh' |head -1 |sed 's/^.*[:] /wget -O boot /' |bash
+  - chmod 755 boot
+script: ./boot run-tests

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 In a terminal do:
 
 ```bash
-mkdir src
-echo -e '(ns foop)\n(.log js/console "hello world")' > src/foop.cljs
+mkdir -p src/foop
+echo -e '(ns foop.core)\n(.log js/console "hello world")' > src/foop/core.cljs
 boot -s src -d adzerk/boot-cljs cljs
 ```
 
@@ -198,6 +198,32 @@ boot cljs -sO advanced
 
 For an example project with a local web server, CLJS REPL, and live-reload,
 check out [boot-cljs-example]!
+
+## Hacking
+
+To build the `boot-cljs` JAR and install to your local Maven repository:
+
+```
+boot build-jar
+```
+
+To run the tests:
+
+```
+boot run-tests
+```
+
+To deploy a snapshot to Clojars:
+
+```
+boot build-jar push-snapshot
+```
+
+To deploy a release to Clojars:
+
+```
+boot build-jar push-release
+```
 
 ## License
 

--- a/build.boot
+++ b/build.boot
@@ -1,10 +1,11 @@
 (set-env!
   :resource-paths #{"src"}
-  :dependencies   '[[org.clojure/clojure       "1.7.0"      :scope "provided"]
-                    [adzerk/bootlaces          "0.1.11"     :scope "test"]
-                    [adzerk/boot-test          "1.0.4"      :scope "test"]
-                    [org.clojure/clojurescript "1.7.48"     :scope "test"]
-                    [ns-tracker                "0.3.0"      :scope "test"]])
+  :dependencies   '[[org.clojure/clojure       "1.7.0"  :scope "provided"]
+                    [adzerk/bootlaces          "0.1.11" :scope "test"]
+                    [adzerk/boot-test          "1.0.4"  :scope "test"]
+                    [pandeiro/boot-http        "0.6.3"  :scope "test"]
+                    [org.clojure/clojurescript "1.7.48" :scope "test"]
+                    [ns-tracker                "0.3.0"  :scope "test"]])
 
 (require '[adzerk.bootlaces   :refer :all]
          '[adzerk.boot-test   :refer [test]]

--- a/src/adzerk/boot_cljs/impl.clj
+++ b/src/adzerk/boot_cljs/impl.clj
@@ -34,13 +34,6 @@
        reverse
        (map #(.getPath (target-file-for-cljs-ns % (:output-dir opts))))))
 
-(defn dep-info [env opts]
-  (let [out-dir (:output-dir opts)
-        all-ns  (ana-api/all-ns env)
-        find-ns #(ana-api/find-ns env %)
-        path-of #(.getPath (target-file-for-cljs-ns % out-dir))]
-    (->> all-ns (reduce #(assoc %1 (path-of %2) (find-ns %2)) {}))))
-
 (defn compile-cljs
   "Given a seq of directories containing CLJS source files and compiler options
   opts, compiles the CLJS to produce JS files.
@@ -58,7 +51,6 @@
       (assoc opts :warning-handlers [default-warning-handler handler])
       stored-env)
     {:warnings  @counter
-     ;:analysis  (dep-info stored-env opts)
      :dep-order (dep-order stored-env opts)}))
 
 (def tracker (atom nil))


### PR DESCRIPTION
- Add missing pandeiro/boot-http dependency.
- Add .travis.yml to run CI tests.
- Minor refactoring:
  - Simplify dependency order merging--builds don't share dependencies.
  - Remove CLJS analysis metadata functions--yagni (for now, at least).
- Add documentation for how to build, install, test, and deploy.