### PR TITLE
Remove artifacts created by other instances of cljs task in pipeline

### DIFF
--- a/test/demo/other.cljs
+++ b/test/demo/other.cljs
@@ -1,0 +1,3 @@
+(ns demo.other)
+
+(set! (-> js/window .-document .-body .-innerText) "test passed")

--- a/test/demo/other.cljs.edn
+++ b/test/demo/other.cljs.edn
@@ -1,0 +1,1 @@
+{:require [demo.other]}

--- a/test/demo/other.html
+++ b/test/demo/other.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+  </head>
+  <body>
+    test failed
+    <script src="other.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
- The format of ids now supports cljs.edn files in subdirectories, for
  example the file foo/bar.cljs.edn would have id foo/bar.