### PR TITLE
Use :directories from within pod, per-pod results dirs

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -28,5 +28,5 @@
   []
   (merge-env! :source-paths #{"test"})
   (comp (serve)
-        (cljs)
+        (cljs :optimizations :whitespace)
         (test :namespaces #{'adzerk.boot-cljs-test})))

--- a/test/demo/core.cljs
+++ b/test/demo/core.cljs
@@ -1,3 +1,3 @@
 (ns demo.core)
 
-(set! (-> js/window .-document .-body .-innerText) "test passed")
+(.appendChild (.-body js/document) (.createTextNode js/document "test passed"))

--- a/test/demo/index.html
+++ b/test/demo/index.html
@@ -3,7 +3,6 @@
   <head>
   </head>
   <body>
-    test failed
     <script src="index.js"></script>
   </body>
 </html>

--- a/test/demo/other.cljs
+++ b/test/demo/other.cljs
@@ -1,3 +1,3 @@
 (ns demo.other)
 
-(set! (-> js/window .-document .-body .-innerText) "test passed")
+(.appendChild (.-body js/document) (.createTextNode js/document "test passed"))

--- a/test/demo/other.html
+++ b/test/demo/other.html
@@ -3,7 +3,6 @@
   <head>
   </head>
   <body>
-    test failed
     <script src="other.js"></script>
   </body>
 </html>


### PR DESCRIPTION
- The functions in the impl namespace that need the classpath
  directories now obtain them from #'boot.pod/env instead of from the
  parent pod.

- Each pod has its own tmp-result dir now, so there is no mingling of
  builds -- the cljs compiler can't know anything about any other builds
  now.