### PR TITLE
Add support for closure modules

### DIFF
--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -117,6 +117,7 @@
                                  (assoc :ns-name (:main-ns-name initial-ctx))))
                 (wrap/compiler-options task-opts)
                 (wrap/main write-main?)
+                (wrap/modules)
                 wrap/source-map)
         tmp (:tmp-out initial-ctx)
         out (.getPath (file/relative-to tmp (-> ctx :opts :output-to)))]


### PR DESCRIPTION
Adds support for `:modules` key on `.cljs.edn`. The value is used to set
`:modules` key for ClojureScript compiler. `:output-to` values are
automatically generated for each module based on path of `.cljs.edn`
file and module key.

Saapas has very quick test for this: https://github.com/Deraen/saapas/compare/closure-modules?expand=1

But because the project is small and there is not really different code in modules, all the code is getting included in cljs-base module. Also, I don't know how to test this.

Testing would be most welcome.