### PR TITLE
Fix :main with optimizations :none

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -22,9 +22,10 @@
        :license     {"EPL" "http://www.eclipse.org/legal/epl-v10.html"}})
 
 (deftask run-tests
-  [j junit-output-to JUNIT str ""]
+  [O optimizations   LEVEL kw  "Compiler optimization level."
+   j junit-output-to JUNIT str "Test report destination."]
   (comp (serve)
-        (cljs :optimizations :whitespace)
+        (cljs :optimizations (or optimizations :whitespace))
         (test :namespaces #{'adzerk.boot-cljs-test 'adzerk.boot-cljs.util-test}
               :junit-output-to junit-output-to)))
 

--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -75,7 +75,7 @@
         (update-in [:opts :asset-path] #(if % % asset-path))
         (set-option :output-dir out-path)
         (set-option :output-to js-path)
-        (set-option :main main))))
+        (set-option :main cljs-ns))))
 
 (defn modules
   "If .cljs.edn file contains modules declaration, use it to create options


### PR DESCRIPTION
When introducing the compiler warnings in commit dc73bd26c7531ab768e92b7a4202ce2e6c7dea38 the `:main` option broke. In order to verify the faulty behavior, I added an option for setting the compilation optimization level when running the tests.

Before the fixing commit `boot run-tests -O none`would fail, now it is green again.