### PR TITLE
forward-slashed ids for Windows

### DIFF
--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -82,9 +82,9 @@
        (map core/tmp-path)))
 
 (defn main-files [fileset ids]
-   (let [re-pat #(re-pattern (str "^\\Q" % "\\E\\.cljs\\.edn$"))
+   (let [rel-paths (map #(io/as-relative-path (str % ".cljs.edn")) ids)
          select (if (seq ids)
-                  #(core/by-re (map re-pat ids) %)
+                  #(core/by-path rel-paths %)
                   #(core/by-ext [".cljs.edn"] %))]
      (->> fileset
           core/input-files


### PR DESCRIPTION
Forward-slash-separated ids are supported on Windows.

e.g.
:ids #{"js/main"} instead of :ids #{"js\\main"}