### PR TITLE
Change the order compiler-options are merged

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+**[compare](https://github.com/adzerk-oss/boot-cljs/compare/1.7.228-1...master)**
+
+- Changed the order compiler-options are merged. Task-options are now merged on top of
+options from .cljs.edn. This allows overriding some options per build task.
+
 ## 1.7.228-1 (11.1.2016)
 
 **[compare](https://github.com/adzerk-oss/boot-cljs/compare/1.7.228-0...1.7.228-1)**

--- a/src/adzerk/boot_cljs.clj
+++ b/src/adzerk/boot_cljs.clj
@@ -186,7 +186,14 @@
 
   The --compiler-options option can be used to set any other options that should
   be passed to the Clojurescript compiler. A full list of options can be found
-  here: https://github.com/clojure/clojurescript/wiki/Compiler-Options."
+  here: https://github.com/clojure/clojurescript/wiki/Compiler-Options.
+
+  Cljs compiler options are merged in this order:
+
+  1. :compiler-options in .cljs.edn file
+  2. :compiler-options task option
+  3. :optimizations and :source-map task options
+  4. options automatically set by boot-cljs (:output-dir, :output-to, :main)"
 
   [i ids IDS               #{str} ""
    O optimizations LEVEL   kw   "The optimization level."

--- a/src/adzerk/boot_cljs/middleware.clj
+++ b/src/adzerk/boot_cljs/middleware.clj
@@ -40,9 +40,9 @@
 (defn compiler-options
   [{:keys [opts main] :as ctx}
    {:keys [compiler-options] :as task-options}]
-  (assoc ctx :opts (merge (select-keys task-options [:optimizations :source-map])
+  (assoc ctx :opts (merge (:compiler-options main)
                           compiler-options
-                          (:compiler-options main))))
+                          (select-keys task-options [:optimizations :source-map]))))
 
 (defn set-option [ctx k value]
   (when-let [current-value (get-in ctx [:opts k])]
@@ -72,6 +72,7 @@
         (io/make-parents)
         (spit (format-ns-forms (main-ns-forms cljs-ns init-nss init-fns)))))
     (-> ctx
+        ;; Only update asset-path in not set
         (update-in [:opts :asset-path] #(if % % asset-path))
         (set-option :output-dir out-path)
         (set-option :output-to js-path)


### PR DESCRIPTION
Before:
- :optimizations and :source-map task options
- :compiler-options task option
- :compiler-options from .cljs.edn file
- options automatically set by boot.cljs

Now:
- :compiler-options from .cljs.edn file
- :compiler-options task option
- :optimizations and :source-map task options
- options automatically set by boot.cljs

I think this should be quite safe change. This will enable more easily changing some options per build task. E.g. adding devtools preload option to .cljs.edn and overwriting it with empty option in production task. As previously, it will be possible to only add preloads option in dev task.